### PR TITLE
Installed jasmine [closes #8]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@
 .byebug_history
 .vagrant
 .env
+coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,4 @@ env:
 script:
   - bundle exec rake db:drop db:create db:migrate
   - bundle exec rake ci:travis
+  - bundle exec rake jasmine:ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,9 @@ rvm:
   - 2.2.2
 
 cache:
-  - bundler
+  bundler: true
+  directories:
+    - $HOME/.phantomjs
 
 gemfile:
   - Gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,3 @@ env:
 script:
   - bundle exec rake db:drop db:create db:migrate
   - bundle exec rake ci:travis
-  - bundle exec rake jasmine:ci

--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,10 @@ gem 'dotenv-rails', :groups => [:development, :test]
 gem 'sprockets'
 gem 'sprockets-es6'
 
+group :development, :test do
+  gem 'jasmine'
+end
+
 group :test do
   gem 'rails-controller-testing'
   gem 'machinist', '~>2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,12 @@ GEM
     globalid (0.3.7)
       activesupport (>= 4.1.0)
     i18n (0.7.0)
+    jasmine (2.4.0)
+      jasmine-core (~> 2.4)
+      phantomjs
+      rack (>= 1.2.1)
+      rake
+    jasmine-core (2.4.1)
     jbuilder (2.6.0)
       activesupport (>= 3.0.0, < 5.1)
       multi_json (~> 1.2)
@@ -121,6 +127,7 @@ GEM
     nokogiri (1.6.8)
       mini_portile2 (~> 2.1.0)
       pkg-config (~> 1.1.7)
+    phantomjs (2.1.1.0)
     pkg-config (1.1.7)
     poltergeist (1.10.0)
       capybara (~> 2.1)
@@ -231,6 +238,7 @@ DEPENDENCIES
   database_cleaner (~> 1.5)
   dotenv-rails
   faker
+  jasmine
   jbuilder (~> 2.5)
   jquery-rails
   listen (~> 3.0.5)

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ bundle install
 ```bash
 cp .env.example .env              # environment configs (change it according to your settings)
 bundle install                    # install dependencies
-rake db:create                    # crete database
-rake db:migrate                   # create tables
+bundle exe rake db:create         # crete database
+bundle exe rake db:migrate        # create tables
 ./bin/create_dummy_data           # loads dummy data
 ```
 
@@ -51,8 +51,8 @@ vagrant up
 vagrant ssh
 gem install bundler               # install dependency manager
 bundle install                    # install dependencies
-rake db:create                    # crete database
-rake db:migrate                   # create tables
+bundle exe rake db:create         # crete database
+bundle exe rake db:migrate        # create tables
 ./bin/create_dummy_data           # loads dummy data
 rails
 ```
@@ -64,3 +64,22 @@ rails s -b 0.0.0.0
 ```
 
 Navigate to [http://localhost:3003](http://localhost:3003) and login as:
+
+
+#### Running tests
+
+```
+RAILS_ENV=test bundle exec rake db:create     # create test database
+RAILS_ENV=test bundle exec rake db:migrate    # create test tables
+bundle exec rake test                         # execute ruby tests
+bundle exec rake jasmine:ci                   # execute javascript tests
+bundle exec rake test:all                     # execute all tests
+```
+
+##### Testing JS on the browser:
+
+```
+bundle exec rake jasmine  # starts server on port 8888
+```
+
+Open http://localhost:8888 in the browser

--- a/Rakefile
+++ b/Rakefile
@@ -23,6 +23,6 @@ namespace :ci do
   desc "run tests on travis"
   task :travis do
     ENV['COVERALLS'] = 'true'
-    Rake::Task['test:coverage'].invoke
+    Rake::Task['test:all'].invoke
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -11,6 +11,12 @@ namespace :test do
     ENV['CODE_COVERAGE'] = 'true'
     Rake::Task['test'].invoke
   end
+
+  desc "run all kinds of tests"
+  task :all do
+    Rake::Task['test'].invoke
+    Rake::Task['jasmine:ci'].invoke
+  end
 end
 
 namespace :ci do

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,6 +6,7 @@ require_relative "vagrant/vagrant_helper"
 Vagrant.configure(2) do |config|
   config.vm.box = "ubuntu/trusty64"
   config.vm.network "forwarded_port", guest: 3000, host: 3003
+  config.vm.network "forwarded_port", guest: 8888, host: 8888
   config.vm.hostname = "gifted.dev"
   config.ssh.forward_agent = true
 

--- a/app/assets/javascripts/jasmine_examples/Player.es6
+++ b/app/assets/javascripts/jasmine_examples/Player.es6
@@ -1,0 +1,22 @@
+class Player {
+    play(song) {
+      this.currentlyPlayingSong = song;
+      this.isPlaying = true;
+    }
+
+    pause() {
+      this.isPlaying = false;
+    }
+
+    resume() {
+      if (this.isPlaying) {
+        throw new Error("song is already playing");
+      }
+
+      this.isPlaying = true;
+    };
+
+    makeFavorite() {
+      this.currentlyPlayingSong.persistFavoriteStatus(true);
+    };
+}

--- a/app/assets/javascripts/jasmine_examples/Song.js
+++ b/app/assets/javascripts/jasmine_examples/Song.js
@@ -1,0 +1,7 @@
+function Song() {
+}
+
+Song.prototype.persistFavoriteStatus = function(value) {
+  // something complicated
+  throw new Error("not yet implemented");
+};

--- a/spec/javascripts/helpers/jasmine_examples/SpecHelper.js
+++ b/spec/javascripts/helpers/jasmine_examples/SpecHelper.js
@@ -1,0 +1,15 @@
+beforeEach(function () {
+  jasmine.addMatchers({
+    toBePlaying: function () {
+      return {
+        compare: function (actual, expected) {
+          var player = actual;
+
+          return {
+            pass: player.currentlyPlayingSong === expected && player.isPlaying
+          };
+        }
+      };
+    }
+  });
+});

--- a/spec/javascripts/jasmine_examples/PlayerSpec.js
+++ b/spec/javascripts/jasmine_examples/PlayerSpec.js
@@ -1,0 +1,58 @@
+describe("Player", function() {
+  var player;
+  var song;
+
+  beforeEach(function() {
+    player = new Player();
+    song = new Song();
+  });
+
+  it("should be able to play a Song", function() {
+    player.play(song);
+    expect(player.currentlyPlayingSong).toEqual(song);
+
+    //demonstrates use of custom matcher
+    expect(player).toBePlaying(song);
+  });
+
+  describe("when song has been paused", function() {
+    beforeEach(function() {
+      player.play(song);
+      player.pause();
+    });
+
+    it("should indicate that the song is currently paused", function() {
+      expect(player.isPlaying).toBeFalsy();
+
+      // demonstrates use of 'not' with a custom matcher
+      expect(player).not.toBePlaying(song);
+    });
+
+    it("should be possible to resume", function() {
+      player.resume();
+      expect(player.isPlaying).toBeTruthy();
+      expect(player.currentlyPlayingSong).toEqual(song);
+    });
+  });
+
+  // demonstrates use of spies to intercept and test method calls
+  it("tells the current song if the user has made it a favorite", function() {
+    spyOn(song, 'persistFavoriteStatus');
+
+    player.play(song);
+    player.makeFavorite();
+
+    expect(song.persistFavoriteStatus).toHaveBeenCalledWith(true);
+  });
+
+  //demonstrates use of expected exceptions
+  describe("#resume", function() {
+    it("should throw an exception if song is already playing", function() {
+      player.play(song);
+
+      expect(function() {
+        player.resume();
+      }).toThrowError("song is already playing");
+    });
+  });
+});

--- a/spec/javascripts/jasmine_examples/PlayerSpec2_spec.es6
+++ b/spec/javascripts/jasmine_examples/PlayerSpec2_spec.es6
@@ -1,0 +1,5 @@
+describe("Player ES6", () => {
+  it("should be able to play a Song", () => {
+      expect(1).toEqual(1);
+  });
+});

--- a/spec/javascripts/support/jasmine.yml
+++ b/spec/javascripts/support/jasmine.yml
@@ -1,0 +1,136 @@
+# src_files
+#
+# Return an array of filepaths relative to src_dir to include before jasmine specs.
+# Default: []
+#
+# EXAMPLE:
+#
+# src_files:
+#   - lib/source1.js
+#   - lib/source2.js
+#   - dist/**/*.js
+#
+src_files:
+  - assets/application.js
+
+# stylesheets
+#
+# Return an array of stylesheet filepaths relative to src_dir to include before jasmine specs.
+# Default: []
+#
+# EXAMPLE:
+#
+# stylesheets:
+#   - css/style.css
+#   - stylesheets/*.css
+#
+stylesheets:
+  - assets/application.css
+
+# helpers
+#
+# Return an array of filepaths relative to spec_dir to include before jasmine specs.
+# Default: ["helpers/**/*.js"]
+#
+# EXAMPLE:
+#
+# helpers:
+#   - helpers/**/*.js
+#
+helpers:
+  - 'helpers/**/*.js'
+
+# spec_files
+#
+# Return an array of filepaths relative to spec_dir to include.
+# Default: ["**/*[sS]pec.js"]
+#
+# EXAMPLE:
+#
+# spec_files:
+#   - **/*[sS]pec.js
+#
+spec_files:
+  - '**/*[sS]pec.js'
+  - '**/*[sS]pec.es6'
+
+# src_dir
+#
+# Source directory path. Your src_files must be returned relative to this path. Will use root if left blank.
+# Default: project root
+#
+# EXAMPLE:
+#
+# src_dir: public
+#
+src_dir:
+
+# spec_dir
+#
+# Spec directory path. Your spec_files must be returned relative to this path.
+# Default: spec/javascripts
+#
+# EXAMPLE:
+#
+# spec_dir: spec/javascripts
+#
+spec_dir:
+
+# spec_helper
+#
+# Ruby file that Jasmine server will require before starting.
+# Returned relative to your root path
+# Default spec/javascripts/support/jasmine_helper.rb
+#
+# EXAMPLE:
+#
+# spec_helper: spec/javascripts/support/jasmine_helper.rb
+#
+spec_helper: spec/javascripts/support/jasmine_helper.rb
+
+# boot_dir
+#
+# Boot directory path. Your boot_files must be returned relative to this path.
+# Default: Built in boot file
+#
+# EXAMPLE:
+#
+# boot_dir: spec/javascripts/support/boot
+#
+boot_dir:
+
+# boot_files
+#
+# Return an array of filepaths relative to boot_dir to include in order to boot Jasmine
+# Default: Built in boot file
+#
+# EXAMPLE
+#
+# boot_files:
+#   - '**/*.js'
+#
+boot_files:
+
+# rack_options
+#
+# Extra options to be passed to the rack server
+# by default, Port and AccessLog are passed.
+#
+# This is an advanced options, and left empty by default
+#
+# EXAMPLE
+#
+# rack_options:
+#   server: 'thin'
+
+# random
+#
+# Run specs in semi-random order.
+# Default: false
+#
+# EXAMPLE:
+#
+# random: true
+#
+random:
+

--- a/spec/javascripts/support/jasmine_helper.rb
+++ b/spec/javascripts/support/jasmine_helper.rb
@@ -1,0 +1,15 @@
+#Use this file to set/override Jasmine configuration options
+#You can remove it if you don't need it.
+#This file is loaded *after* jasmine.yml is interpreted.
+#
+#Example: using a different boot file.
+#Jasmine.configure do |config|
+#   config.boot_dir = '/absolute/path/to/boot_dir'
+#   config.boot_files = lambda { ['/absolute/path/to/boot_dir/file.js'] }
+#end
+#
+#Example: prevent PhantomJS auto install, uses PhantomJS already on your path.
+#Jasmine.configure do |config|
+#   config.prevent_phantom_js_auto_install = true
+#end
+#


### PR DESCRIPTION
See the new instructions on the Readme.

This change needs `vagrant reload`.

The only problem in the moment is that the es6 specs are not run in the cli `rake jasmine:ci`.

It is a nice to have.

We can still check the jest tool if you want, @nthiebes. I just went for the tools that I already know how to use.
